### PR TITLE
use go1.6 and break on 'go vet' errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
 language: go
+
+go: 1.6
+
+before_script:
+  - go vet ./...


### PR DESCRIPTION
before_script as described in https://docs.travis-ci.com/user/customizing-the-build/ or https://robots.thoughtbot.com/configure-travis-ci-for-go