### PR TITLE
Fixed broken -e flag for go-model

### DIFF
--- a/rdl/go-model.go
+++ b/rdl/go-model.go
@@ -56,7 +56,7 @@ func GenerateGoModel(banner string, schema *rdl.Schema, outdir string, ns string
 	}
 	out.Flush()
 	if gen.err == nil {
-		gen.err = GenerateGoSchema(banner, schema, outdir, ns, librdl)
+		gen.err = GenerateGoSchema(banner, schema, outdir, ns, librdl, prefixEnums)
 	}
 	return gen.err
 }

--- a/rdl/go-schema.go
+++ b/rdl/go-schema.go
@@ -261,11 +261,9 @@ func (gen *schemaGenerator) emitStructType(typedef *rdl.StructTypeDef) {
 			switch gen.registry.FindBaseType(f.Type) {
 			case rdl.BaseTypeEnum:
 				if gen.prefixEnums {
-					fmt.Println("prefix this:", f)
 					def = fmt.Sprint(f.Default)
 					def = SnakeToCamel(def)
 					def = capitalize(string(f.Type)) + def
-					fmt.Println("->", def)
 				} else {
 					def = fmt.Sprint(f.Default)
 				}

--- a/rdl/go-schema.go
+++ b/rdl/go-schema.go
@@ -13,19 +13,20 @@ import (
 )
 
 type schemaGenerator struct {
-	registry  rdl.TypeRegistry
-	schema    *rdl.Schema
-	name      string
-	writer    *bufio.Writer
-	err       error
-	banner    string
-	ns        string
-	librdl    string
-	rdlprefix string
+	registry    rdl.TypeRegistry
+	schema      *rdl.Schema
+	name        string
+	writer      *bufio.Writer
+	err         error
+	banner      string
+	ns          string
+	librdl      string
+	rdlprefix   string
+	prefixEnums bool
 }
 
 // GenerateGoSchema generates the code to regenerate the Schema
-func GenerateGoSchema(banner string, schema *rdl.Schema, outdir string, ns string, librdl string) error {
+func GenerateGoSchema(banner string, schema *rdl.Schema, outdir string, ns string, librdl string, prefixEnums bool) error {
 	name := strings.ToLower(string(schema.Name))
 	if strings.HasSuffix(outdir, ".go") {
 		name = filepath.Base(outdir)
@@ -44,7 +45,7 @@ func GenerateGoSchema(banner string, schema *rdl.Schema, outdir string, ns strin
 	if schema.Name == "rdl" {
 		rdlprefix = ""
 	}
-	gen := &schemaGenerator{rdl.NewTypeRegistry(schema), schema, capitalize(string(schema.Name)), out, nil, banner, ns, librdl, rdlprefix}
+	gen := &schemaGenerator{rdl.NewTypeRegistry(schema), schema, capitalize(string(schema.Name)), out, nil, banner, ns, librdl, rdlprefix, prefixEnums}
 	gen.emit(generationHeader(banner))
 	gen.emit("\n\npackage " + generationPackage(gen.schema, gen.ns) + "\n\n")
 	if gen.schema.Name != "rdl" {
@@ -257,11 +258,24 @@ func (gen *schemaGenerator) emitStructType(typedef *rdl.StructTypeDef) {
 		}
 		def := "nil"
 		if f.Default != nil {
-			switch f.Default.(type) {
-			case string:
-				def = fmt.Sprintf("%q", f.Default)
+			switch gen.registry.FindBaseType(f.Type) {
+			case rdl.BaseTypeEnum:
+				if gen.prefixEnums {
+					fmt.Println("prefix this:", f)
+					def = fmt.Sprint(f.Default)
+					def = SnakeToCamel(def)
+					def = capitalize(string(f.Type)) + def
+					fmt.Println("->", def)
+				} else {
+					def = fmt.Sprint(f.Default)
+				}
 			default:
-				def = fmt.Sprint(f.Default)
+				switch f.Default.(type) {
+				case string:
+					def = fmt.Sprintf("%q", f.Default)
+				default:
+					def = fmt.Sprint(f.Default)
+				}
 			}
 		}
 		gen.emit(fmt.Sprintf("\t%s.Field(%q, %q, %v, %v, %q)\n", varname, f.Name, f.Type, f.Optional, def, f.Comment))


### PR DESCRIPTION
Previously, using the -e flag to prefix enum constants did not get respected in the go-schema generation, resulting in files that would not compile if a field had a default enum value.