### PR TITLE
Make client accept a RoundTripper rather than a Transport

### DIFF
--- a/rdl/go-client.go
+++ b/rdl/go-client.go
@@ -72,14 +72,14 @@ var _ = ioutil.NopCloser
 
 type {{client}} struct {
 	URL         string
-	Transport   *http.Transport
+	Transport   http.RoundTripper
 	CredsHeader *string
 	CredsToken  *string
 	Timeout     time.Duration
 }
 
 // NewClient creates and returns a new HTTP client object for the {{.Name}} service
-func NewClient(url string, transport *http.Transport) {{client}} {
+func NewClient(url string, transport http.RoundTripper) {{client}} {
 	return {{client}}{url, transport, nil, nil, 0}
 }
 


### PR DESCRIPTION
Should be 100% back-compatible since interface is more general than concrete class.