### PR TITLE
Enable external generators to accept custom options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ src/
 bin/
 pkg/
 .deps
-
+*.iml
+.idea


### PR DESCRIPTION
This PR attempts to increase external generator flexibility by allowing users to set custom options specific to their generators.

For example:

running _rdl generate **-x e=true -xfoo=bar** myGenerator myRdl.rdl_

will result in rdl calling rdl-gen-myGenerator with **-e true --foo bar**
