### PR TITLE
Let Swagger determine scheme automatically using request scheme

### DIFF
--- a/rdl-gen/rdl-gen-swagger/main.go
+++ b/rdl-gen/rdl-gen-swagger/main.go
@@ -119,7 +119,7 @@ func swagger(schema *rdl.Schema) (*SwaggerDoc, error) {
 	sname := string(schema.Name)
 	swag := new(SwaggerDoc)
 	swag.Swagger = "2.0"
-	swag.Schemes = []string{"http"}
+	swag.Schemes = []string{}
 	//swag.Host = "localhost"
 	swag.BasePath = "/api"
 


### PR DESCRIPTION
Currently RDL generated Swagger definitions are HTTP only.  This PR allows Swagger to determine scheme automatically via access scheme to support both HTTP and HTTPS.

Reference from Swagger spec:

_The transfer protocol of the API. Values MUST be from the list: "http", "https", "ws", "wss". If the schemes is not included, the default scheme to be used is the one used to access the Swagger definition itself._

I've tested the generated definition with Swagger-UI and it switches schemes automatically.

Thanks
