### PR TITLE
Fixed incorrect ref key and array inheritance

### DIFF
--- a/rdl-gen/rdl-gen-swagger/main.go
+++ b/rdl-gen/rdl-gen-swagger/main.go
@@ -309,6 +309,9 @@ func makeSwaggerTypeDef(reg rdl.TypeRegistry, t *rdl.Type) *SwaggerType {
 				switch fbt {
 				case rdl.BaseTypeArray:
 					prop.Type = "array"
+					if ft.Variant == rdl.TypeVariantArrayTypeDef && f.Items == "" {
+						f.Items = ft.ArrayTypeDef.Items
+					}
 					if f.Items != "" {
 						fitems := string(f.Items)
 						items := new(SwaggerType)
@@ -329,7 +332,7 @@ func makeSwaggerTypeDef(reg rdl.TypeRegistry, t *rdl.Type) *SwaggerType {
 					prop.Type = "integer"
 					prop.Format = strings.ToLower(fbt.String())
 				case rdl.BaseTypeStruct:
-					prop.Type = "#/definitions/" + string(f.Type)
+					prop.Ref = "#/definitions/" + string(f.Type)
 				case rdl.BaseTypeMap:
 					prop.Type = "object"
 					if f.Items != "" {


### PR DESCRIPTION
This PR addresses two issues that are causing Swagger generator to produce broken definitions.

1. Inherited arrays are not generated correctly (ipAddress):

```
"IpAddresses": {
        "type": "Array",
        "items": {
                "type": "string"
        }
},

"MyTestStruct": {
        "properties": {
                "ipAddress": {
                    "type": "array"
                }
        },
        "required": [
                "ipAddress"
        ]
},
```

2. Inherited struct type has incorrect ref key (should be $ref):

```
"myTestStruct": {
        "type": "#/definitions/MyTestStruct"
}
```

References: 

- [test swagger.rdl](https://gist.github.com/ben-tsai/378eb5dbd4a0eab5850b17e9b9947bc3)
- [incorrect output](https://gist.github.com/ben-tsai/a447a78aa80b30bbf55005a72a6dd26d)
- [correct output](https://gist.github.com/ben-tsai/4e260c70f2b505b5790277dca95b514c)

Thanks