### PR TITLE
Provide option -g option to generate get/setters for java-model

### DIFF
--- a/rdl/java-client.go
+++ b/rdl/java-client.go
@@ -98,14 +98,33 @@ import com.yahoo.rdl.*;
 import javax.ws.rs.client.*;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
+import javax.net.ssl.HostnameVerifier;
 
 public class {{cName}}Client {
+    Client client;
     WebTarget base;
     String credsHeader;
     String credsToken;
 
     public {{cName}}Client(String url) {
-        base = ClientBuilder.newClient().target(url);
+        client = ClientBuilder.newClient();
+        base = client.target(url);
+    }
+
+    public {{cName}}Client(String url, HostnameVerifier hostnameVerifier) {
+        client = ClientBuilder.newBuilder()
+            .hostnameVerifier(hostnameVerifier)
+            .build();
+        base = client.target(url);
+    }
+
+    public void close() {
+        client.close();
+    }
+
+    public {{cName}}Client setProperty(String name, Object value) {
+        client = client.property(name, value);
+        return this;
     }
 
     public {{cName}}Client addCredentials(String header, String token) {


### PR DESCRIPTION
e.g. rdl generate -g java-model ./rdl/ZMS.rdl

generates model classes with getter/setter methods. By default the option is turned off.