### PR TITLE
One possible solution to issue #40

### DIFF
--- a/rdl/java-client.go
+++ b/rdl/java-client.go
@@ -104,10 +104,6 @@ import javax.ws.rs.client.*;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import javax.net.ssl.HostnameVerifier;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.List;
-import java.util.ArrayList;
 
 public class {{cName}}Client {
     Client client;
@@ -159,9 +155,9 @@ func (gen *javaClientGenerator) clientMethodSignature(r *rdl.Resource) string {
 	}
 	if len(r.Outputs) > 0 {
 		if sparams == "" {
-			sparams = "Map<String,List<String>> headers"
+			sparams = "java.util.Map<String,java.util.List<String>> headers"
 		} else {
-			sparams = sparams + ", Map<String,List<String>> headers"
+			sparams = sparams + ", java.util.Map<String,java.util.List<String>> headers"
 		}
 	}
 	return "public " + returnType + " " + methName + "(" + sparams + ")"
@@ -225,7 +221,7 @@ func (gen *javaClientGenerator) clientMethodBody(r *rdl.Resource) string {
 	if len(r.Outputs) > 0 {
 		s += "            if (headers != null) {\n"
 		for _, out := range r.Outputs {
-			s += "                headers.put(\"" + string(out.Name) + "\", Arrays.asList((String)response.getHeaders().getFirst(\"" + out.Header + "\")));\n"
+			s += "                headers.put(\"" + string(out.Name) + "\", java.util.Arrays.asList((String)response.getHeaders().getFirst(\"" + out.Header + "\")));\n"
 		}
 		s += "            }\n"
 	}

--- a/rdl/java-client.go
+++ b/rdl/java-client.go
@@ -104,6 +104,10 @@ import javax.ws.rs.client.*;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import javax.net.ssl.HostnameVerifier;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 
 public class {{cName}}Client {
     Client client;
@@ -152,6 +156,13 @@ func (gen *javaClientGenerator) clientMethodSignature(r *rdl.Resource) string {
 	sparams := ""
 	if len(params) > 0 {
 		sparams = strings.Join(params, ", ")
+	}
+	if len(r.Outputs) > 0 {
+		if sparams == "" {
+			sparams = "Map<String,List<String>> headers"
+		} else {
+			sparams = sparams + ", Map<String,List<String>> headers"
+		}
 	}
 	return "public " + returnType + " " + methName + "(" + sparams + ")"
 }
@@ -211,6 +222,14 @@ func (gen *javaClientGenerator) clientMethodBody(r *rdl.Resource) string {
 		expected += "|| status.equals(\"" + alt + "\")"
 	}
 	s += "        if (" + expected + ") {\n"
+	if len(r.Outputs) > 0 {
+		s += "            if (headers != null) {\n"
+		for _, out := range r.Outputs {
+			s += "                headers.put(\"" + string(out.Name) + "\", Arrays.asList((String)response.getHeaders().getFirst(\"" + out.Header + "\")));\n"
+		}
+		s += "            }\n"
+	}
+
 	s += "            return response.readEntity(" + returnType + ".class);\n"
 	if r.Exceptions != nil {
 		for k, v := range r.Exceptions {


### PR DESCRIPTION
Incompatible with previous generator, though.

Should it be enabled with an optional flag to maintain compatibility? It is arguable that if you had an API with an output header, it was broken anyway, and if you don't have an API with output headers, it should change, functionally.

It does introduce "import java.util.Map" et al, so that may trigger some style checkers that it didn't before.
