### PR TITLE
update java client generation

### DIFF
--- a/rdl/java-client.go
+++ b/rdl/java-client.go
@@ -212,12 +212,26 @@ func (gen *javaClientGenerator) clientMethodBody(r *rdl.Resource) string {
 		s += "        Response response = invocationBuilder." + strings.ToLower(r.Method) + "();\n"
 	}
 	s += "        int code = response.getStatus();\n"
-	s += "        String status = Response.Status.fromStatusCode(code).toString();\n"
-	expected := "status.equals(\"" + r.Expected + "\")"
-	for _, alt := range r.Alternatives {
-		expected += "|| status.equals(\"" + alt + "\")"
+	s += "        switch (code) {\n"
+
+	//loop for all expected results
+	var expected []string
+	expected = append(expected, rdl.StatusCode(r.Expected))
+	couldBeNoContent := "NO_CONTENT" == r.Expected
+	couldBeNotModified := "NOT_MODIFIED" == r.Expected
+	noContent := couldBeNoContent && r.Alternatives == nil
+	for _, e := range r.Alternatives {
+		if "NO_CONTENT" == e {
+			couldBeNoContent = true
+		}
+		if "NOT_MODIFIED" == e {
+			couldBeNotModified = true
+		}
+		expected = append(expected, rdl.StatusCode(e))
 	}
-	s += "        if (" + expected + ") {\n"
+	for _, expCode := range expected {
+		s += "        case " + expCode + ":\n"
+	}
 	if len(r.Outputs) > 0 {
 		s += "            if (headers != null) {\n"
 		for _, out := range r.Outputs {
@@ -225,16 +239,34 @@ func (gen *javaClientGenerator) clientMethodBody(r *rdl.Resource) string {
 		}
 		s += "            }\n"
 	}
-
-	s += "            return response.readEntity(" + returnType + ".class);\n"
-	if r.Exceptions != nil {
-		for k, v := range r.Exceptions {
-			s += "        } else if (status.equals(\"" + k + "\")) {\n"
-			s += "            throw new ResourceException(code, response.readEntity(" + v.Type + ".class));\n"
+	if noContent {
+		s += "            return null;\n"
+	} else {
+		if couldBeNoContent || couldBeNotModified {
+			s += "            if (" + gen.responseCondition(couldBeNoContent, couldBeNotModified) + ") {\n"
+			s += "                return null;\n"
+			s += "            }\n"
 		}
+		s += "            return response.readEntity(" + returnType + ".class);\n"
 	}
-	s += "        } else {\n"
-	s += "            throw new ResourceException(code, response.readEntity(Object.class));\n"
+	s += "        default:\n"
+	if r.Exceptions != nil {
+		s += "            throw new ResourceException(code, response.readEntity(ResourceError.class));\n"
+	} else {
+		s += "            throw new ResourceException(code, response.readEntity(Object.class));\n"
+	}
 	s += "        }\n"
+	return s
+}
+
+func (gen *javaClientGenerator) responseCondition(noContent, notModified bool) string {
+	var s string
+	if noContent && notModified {
+		s += "code == " + rdl.StatusCode("NO_CONTENT") + " || code == " + rdl.StatusCode("NOT_MODIFIED")
+	} else if noContent {
+		s += "code == " + rdl.StatusCode("NO_CONTENT")
+	} else {
+		s += "code == " + rdl.StatusCode("NOT_MODIFIED")
+	}
 	return s
 }


### PR DESCRIPTION
This PR addresses the following two issues:

#42 incorrect code generated for NO_CONTENT or NOT_MODIFIED status codes
#43 incorrect code generated to match exceptions

The generated code is based on the http status code rather the string that represents that code and is identical to how we generate the go client code. For example, with the following rdl:

expected OK;
exceptions {
    ResourceError NOT_FOUND;
    ResourceError BAD_REQUEST;
    ResourceError FORBIDDEN;
    ResourceError UNAUTHORIZED;
}

we'll generate code like:

```
int code = response.getStatus();
switch (code) {
case 200:
    return response.readEntity(Domain.class);
default:
    throw new ResourceException(code, response.readEntity(ResourceError.class));
}
```

If we're given with request with NO_CONTENT, then there is no data to read:

expected NO_CONTENT;
 exceptions {
     ResourceError NOT_FOUND;
     ResourceError BAD_REQUEST;
     ResourceError FORBIDDEN;
     ResourceError UNAUTHORIZED;
     ResourceError CONFLICT;
 }

we'll generate the code as:

```
int code = response.getStatus();
switch (code) {
case 204:
    return null;
default:
    throw new ResourceException(code, response.readEntity(ResourceError.class));
}
```

If we have multiple OK, NON_MODIFIED codes:

expected OK, NOT_MODIFIED;
exceptions {
    ResourceError NOT_FOUND;
    ResourceError FORBIDDEN;
    ResourceError UNAUTHORIZED; 
}

then we'll generate as:

```
int code = response.getStatus();
switch (code) {
case 200:
case 304:
    if (headers != null) {
        headers.put("tag", java.util.Arrays.asList((String)response.getHeaders().getFirst("ETag")));
    }
    if (code == 304) {
        return null;
    }
    return response.readEntity(SignedDomains.class);
default:
    throw new ResourceException(code, response.readEntity(ResourceError.class));
}
```
