### PR TITLE
Fix PUTs, POSTs, PATCHes and OPTIONS client code gen when nil body

### DIFF
--- a/rdl/go-client.go
+++ b/rdl/go-client.go
@@ -143,7 +143,10 @@ func (client {{client}}) httpDelete(url string, headers map[string]string) (*htt
 }
 
 func (client {{client}}) httpPut(url string, headers map[string]string, body []byte) (*http.Response, error) {
-	contentReader := bytes.NewReader(body)
+	var contentReader io.Reader
+	if body != nil {
+		contentReader := bytes.NewReader(body)
+	}
 	hclient := client.getClient()
 	req, err := http.NewRequest("PUT", url, contentReader)
 	if err != nil {
@@ -160,7 +163,10 @@ func (client {{client}}) httpPut(url string, headers map[string]string, body []b
 }
 
 func (client {{client}}) httpPost(url string, headers map[string]string, body []byte) (*http.Response, error) {
-	contentReader := bytes.NewReader(body)
+	var contentReader io.Reader
+	if body != nil {
+		contentReader := bytes.NewReader(body)
+	}
 	hclient := client.getClient()
 	req, err := http.NewRequest("POST", url, contentReader)
 	if err != nil {
@@ -177,7 +183,10 @@ func (client {{client}}) httpPost(url string, headers map[string]string, body []
 }
 
 func (client {{client}}) httpPatch(url string, headers map[string]string, body []byte) (*http.Response, error) {
-	contentReader := bytes.NewReader(body)
+	var contentReader io.Reader
+	if body != nil {
+		contentReader := bytes.NewReader(body)
+	}
 	hclient := client.getClient()
 	req, err := http.NewRequest("PATCH", url, contentReader)
 	if err != nil {


### PR DESCRIPTION
The httpPut etc. methods create a contentReader as bytes.NewReader(body)
even when the body is nil. This idiom used to work until go 1.6.

In go 1.7 it results in different behavior where the client does not
set the Content-Length: 0 header causing the server to return an error.

Fix this such that the reader is only initialized when the body is non-nil.