### PR TITLE
Added go-server-project generation target

### DIFF
--- a/rdl/go-model.go
+++ b/rdl/go-model.go
@@ -288,19 +288,15 @@ func goType2(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl
 			bt := reg.BaseType(t)
 			switch bt {
 			case rdl.BaseTypeString, rdl.BaseTypeSymbol:
-				fmt.Println("one:", cleanType)
 				return cleanType
 			case rdl.BaseTypeInt8, rdl.BaseTypeInt16, rdl.BaseTypeInt32, rdl.BaseTypeInt64, rdl.BaseTypeFloat32, rdl.BaseTypeFloat64, rdl.BaseTypeBool:
-				fmt.Println("two:", prefix+cleanType)
 				return prefix + cleanType
 			case rdl.BaseTypeTimestamp, rdl.BaseTypeUUID:
 				fullTypeName := rdlPrefix + cleanType
-				fmt.Println("three:", prefix+fullTypeName)
 				return prefix + fullTypeName
 			default:
 				if lrdlType == "struct" {
 					fullTypeName := rdlPrefix + cleanType
-					fmt.Println("four:", prefix+fullTypeName)
 					return prefix + fullTypeName
 				}
 			}
@@ -334,7 +330,6 @@ func goType2(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl
 				name = string(t.ArrayTypeDef.Name)
 			}
 			if name != "Array" {
-				fmt.Println("five:", name)
 				return name
 			}
 		}

--- a/rdl/go-model.go
+++ b/rdl/go-model.go
@@ -6,11 +6,12 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/ardielle/ardielle-go/rdl"
 	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/ardielle/ardielle-go/rdl"
 )
 
 //
@@ -254,6 +255,10 @@ func (gen *modelGenerator) emitTypeComment(t *rdl.Type) {
 }
 
 func goType(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl.TypeRef, keys rdl.TypeRef, precise bool, reference bool) string {
+	return goType2(reg, rdlType, optional, items, keys, precise, reference, "")
+}
+
+func goType2(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl.TypeRef, keys rdl.TypeRef, precise bool, reference bool, packageName string) string {
 	rdlPrefix := "rdl."
 	if reg.Name() == "rdl" {
 		rdlPrefix = ""
@@ -283,16 +288,19 @@ func goType(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl.
 			bt := reg.BaseType(t)
 			switch bt {
 			case rdl.BaseTypeString, rdl.BaseTypeSymbol:
+				fmt.Println("one:", cleanType)
 				return cleanType
 			case rdl.BaseTypeInt8, rdl.BaseTypeInt16, rdl.BaseTypeInt32, rdl.BaseTypeInt64, rdl.BaseTypeFloat32, rdl.BaseTypeFloat64, rdl.BaseTypeBool:
-
+				fmt.Println("two:", prefix+cleanType)
 				return prefix + cleanType
 			case rdl.BaseTypeTimestamp, rdl.BaseTypeUUID:
 				fullTypeName := rdlPrefix + cleanType
+				fmt.Println("three:", prefix+fullTypeName)
 				return prefix + fullTypeName
 			default:
 				if lrdlType == "struct" {
 					fullTypeName := rdlPrefix + cleanType
+					fmt.Println("four:", prefix+fullTypeName)
 					return prefix + fullTypeName
 				}
 			}
@@ -326,6 +334,7 @@ func goType(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl.
 				name = string(t.ArrayTypeDef.Name)
 			}
 			if name != "Array" {
+				fmt.Println("five:", name)
 				return name
 			}
 		}
@@ -338,7 +347,7 @@ func goType(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl.
 				i = items
 			}
 		}
-		gitems := goType(reg, i, false, "", "", precise, reference)
+		gitems := goType2(reg, i, false, "", "", precise, reference, packageName)
 		return "[]" + gitems
 	case rdl.BaseTypeMap:
 		if reference {
@@ -367,8 +376,8 @@ func goType(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl.
 				i = items
 			}
 		}
-		gkeys := goType(reg, k, false, "", "", precise, reference)
-		gitems := goType(reg, i, false, "", "", precise, reference)
+		gkeys := goType2(reg, k, false, "", "", precise, reference, packageName)
+		gitems := goType2(reg, i, false, "", "", precise, reference, packageName)
 		return "map[" + gkeys + "]" + gitems
 	case rdl.BaseTypeStruct:
 		switch t.Variant {
@@ -376,6 +385,9 @@ func goType(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl.
 			if t.AliasTypeDef.Name == "Struct" {
 				return prefix + "map[string]interface{}"
 			}
+		}
+		if packageName != "" {
+			return "*" + packageName + "." + cleanType
 		}
 		return "*" + cleanType
 	case rdl.BaseTypeUnion:

--- a/rdl/go-server-project.go
+++ b/rdl/go-server-project.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	//	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	//	"reflect"
+	//	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/ardielle/ardielle-go/rdl"
+)
+
+//func GenerateGoCommand(...) -> generate a go command that uses the go client in the same project.
+
+func GenerateGoServerProject(rdlSrcPath string, banner string, schema *rdl.Schema, outdir string, ns string, librdl string, prefixEnums bool, preciseTypes bool, untaggedUnions []string) error {
+
+	//1. establish directory structure
+	if strings.HasSuffix(outdir, ".go") {
+		return fmt.Errorf("Output must be a directory: %q", outdir)
+	}
+	rdlSrcFile := filepath.Base(rdlSrcPath)
+	//rdlSrcDir := filepath.Dir(rdlSrcPath)
+	rdlDstDir := filepath.Join(outdir, "rdl")
+	rdlDstPath := filepath.Join(rdlDstDir, rdlSrcFile)
+	err := os.MkdirAll(rdlDstDir, 0755)
+	if err != nil {
+		return err
+	}
+	data, err := ioutil.ReadFile(rdlSrcPath)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(rdlDstPath, data, 0644)
+	if err != nil {
+		return err
+	}
+	name := strings.ToLower(string(schema.Name))
+	gendir := filepath.Join(outdir, name)
+	err = os.MkdirAll(gendir, 0755)
+	if err != nil {
+		return err
+	}
+	err = GenerateGoModel(banner, schema, gendir, "", librdl, prefixEnums, preciseTypes, untaggedUnions)
+	if err != nil {
+		return err
+	}
+	err = GenerateGoServer(banner, schema, gendir, "", librdl, prefixEnums, preciseTypes)
+	if err != nil {
+		return err
+	}
+	daemondir := filepath.Join(outdir, name+"d")
+	err = os.MkdirAll(daemondir, 0755)
+	if err != nil {
+		return err
+	}
+	err = GenerateGoServerMain(banner, schema, daemondir, ns, librdl, prefixEnums, preciseTypes, untaggedUnions)
+	if err != nil {
+		return err
+	}
+	//		err = GenerateGoClient(banner, schema, dirName, ns, librdl, prefixEnums, preciseTypes)
+	//2. generate go model
+	//3. generate go server
+	//4. generate go client
+	//5. generate go command to call client
+	//the end result should be a project that can be tested.
+	return nil
+}
+
+func GenerateGoServerMain(banner string, schema *rdl.Schema, outdir string, ns string, librdl string, prefixEnums bool, preciseTypes bool, untaggedUnions []string) error {
+	out, file, _, err := outputWriter(outdir, "main", ".go")
+	if err != nil {
+		return err
+	}
+	if file != nil {
+		defer file.Close()
+	}
+	registry := rdl.NewTypeRegistry(schema)
+	commentFun := func(s string) string {
+		return formatComment(s, 0, 80)
+	}
+	basenameFunc := func(s string) string {
+		i := strings.LastIndex(s, ".")
+		if i >= 0 {
+			s = s[i+1:]
+		}
+		return s
+	}
+	name := strings.ToLower(string(schema.Name))
+	fieldFun := func(f rdl.StructFieldDef) string {
+		optional := f.Optional
+		fType := goType(registry, f.Type, optional, f.Items, f.Keys, preciseTypes, true)
+		fName := capitalize(string(f.Name))
+		option := ""
+		if optional {
+			option = ",omitempty"
+		}
+		fAnno := "`json:\"" + string(f.Name) + option + "\"`"
+		return fmt.Sprintf("%s %s%s", fName, fType, fAnno)
+	}
+	funcMap := template.FuncMap{
+		"impl": func() string { return capitalize(name) + "Impl" },
+		"module": func() string {
+			if ns == "" {
+				return "../" + name
+			} else {
+				return ns
+			}
+		},
+		"rdlruntime":  func() string { return librdl },
+		"header":      func() string { return generationHeader(banner) },
+		"package":     func() string { return generationPackage(schema, "") },
+		"field":       fieldFun,
+		"flattened":   func(t *rdl.Type) []*rdl.StructFieldDef { return flattenedFields(registry, t) },
+		"typeRef":     func(t *rdl.Type) string { return makeTypeRef(registry, t, preciseTypes) },
+		"basename":    basenameFunc,
+		"comment":     commentFun,
+		"method_sig":  func(r *rdl.Resource) string { return goMethodSignatureImpl(registry, r, preciseTypes) },
+		"method_body": func(r *rdl.Resource) string { return goMethodBodyImpl(registry, r, preciseTypes) },
+		//		"client":      func() string { return name + "Client" },
+	}
+	t := template.Must(template.New("FOO").Funcs(funcMap).Parse(serverMainTemplate))
+	err = t.Execute(out, schema)
+	if err != nil {
+		return err
+	}
+	out.Flush()
+	return nil
+}
+
+func goMethodSignatureImpl(reg rdl.TypeRegistry, r *rdl.Resource, precise bool) string {
+	name := strings.ToLower(string(reg.Name()))
+	noContent := r.Expected == "NO_CONTENT" && r.Alternatives == nil
+	returnSpec := "error"
+	//fixme: no content *with* output headers
+	if !noContent {
+		gtype := goType2(reg, r.Type, false, "", "", precise, true, name)
+		returnSpec = "(" + gtype
+		if r.Outputs != nil {
+			for _, o := range r.Outputs {
+				otype := goType2(reg, o.Type, false, "", "", precise, true, name)
+				returnSpec += ", " + otype
+			}
+		}
+		returnSpec += ", error)"
+	}
+	methName, params := goMethodName2(reg, r, precise, name)
+	paramSpec := "context *rdl.ResourceContext"
+	if len(params) > 0 {
+		paramSpec = paramSpec + ", " + strings.Join(params, ", ")
+	}
+	return capitalize(methName) + "(" + paramSpec + ") " + returnSpec
+}
+
+func goMethodBodyImpl(reg rdl.TypeRegistry, r *rdl.Resource, precise bool) string {
+	noContent := r.Expected == "NO_CONTENT" && r.Alternatives == nil
+	if noContent {
+		return "\treturn &rdl.ResourceError{Code: 501, Message: \"Not Implemented\"}"
+	}
+	return "\treturn nil, &rdl.ResourceError{Code: 501, Message: \"Not Implemented\"}"
+}
+
+var serverMainTemplate = `{{header}}
+
+package main
+
+import (
+	"net/http"
+
+	{{package}} "{{module}}"
+	rdl "{{rdlruntime}}"
+)
+
+func main() {
+	endpoint := "localhost:4080"
+	url := "http://" + endpoint + "/{{package}}"
+	impl := new({{impl}})
+	handler := {{package}}.Init(impl, url, impl)
+	http.ListenAndServe(endpoint, handler)
+}
+
+type {{impl}} struct{}
+{{range .Resources}}
+func (impl {{impl}}) {{method_sig .}} {
+{{method_body .}}
+}
+{{end}}
+//Authenticate - required by the framework. If returning true, you should set context.Principal to a valid object
+func (impl *{{impl}}) Authenticate(context *rdl.ResourceContext) bool {
+	return false
+}
+
+//Authorize - required by the framework. Enforce authorization here.
+func (impl *{{impl}}) Authorize(action string, resource string, principal rdl.Principal) (bool, error) {
+	return true, nil
+}
+`

--- a/rdl/go-server.go
+++ b/rdl/go-server.go
@@ -56,13 +56,14 @@ package {{package}}
 import (
 	"encoding/json"
 	"fmt"
-	"{{httptreemux}}"
-	rdl "{{rdlruntime}}"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
 	"strings"
+
+	rdl "{{rdlruntime}}"
+	"{{httptreemux}}"
 )
 
 var _ = json.Marshal
@@ -569,6 +570,10 @@ func goServerMethodSignature(reg rdl.TypeRegistry, r *rdl.Resource, precise bool
 }
 
 func goMethodName(reg rdl.TypeRegistry, r *rdl.Resource, precise bool) (string, []string) {
+	return goMethodName2(reg, r, precise, "")
+}
+
+func goMethodName2(reg rdl.TypeRegistry, r *rdl.Resource, precise bool, packageName string) (string, []string) {
 	var params []string
 	bodyType := string(safeTypeVarName(r.Type))
 	for _, v := range r.Inputs {
@@ -583,7 +588,7 @@ func goMethodName(reg rdl.TypeRegistry, r *rdl.Resource, precise bool) (string, 
 		if v.Optional {
 			optional = true
 		}
-		params = append(params, goName(string(k))+" "+goType(reg, v.Type, optional, "", "", precise, true))
+		params = append(params, goName(string(k))+" "+goType2(reg, v.Type, optional, "", "", precise, true, packageName))
 	}
 	meth := string(r.Name)
 	if meth == "" {

--- a/rdl/main.go
+++ b/rdl/main.go
@@ -127,7 +127,7 @@ func main() {
 			if schema.Name == "" {
 				schema.Name = name
 			}
-			generate(banner, *generator, *outfile, *librdl, *prefixEnums, *preciseTypes, *ns, schema, *schemaFile, *untaggedUnions, *basePath, *externalOptions)
+			generate(*schemaFile, banner, *generator, *outfile, *librdl, *prefixEnums, *preciseTypes, *ns, schema, *schemaFile, *untaggedUnions, *basePath, *externalOptions)
 		}
 	})
 	app.Run(os.Args)
@@ -195,7 +195,7 @@ func ensureExtension(name string, ext string) string {
 	return name + ext
 }
 
-func generate(banner string, flavor string, dirName string, librdl string, prefixEnums bool, preciseTypes bool, ns string, schema *rdl.Schema, srcFile string, untaggedUnions []string, base string, externalOptions []string) {
+func generate(schemaFile string, banner string, flavor string, dirName string, librdl string, prefixEnums bool, preciseTypes bool, ns string, schema *rdl.Schema, srcFile string, untaggedUnions []string, base string, externalOptions []string) {
 	var err error
 	switch flavor {
 	case "json":
@@ -206,6 +206,8 @@ func generate(banner string, flavor string, dirName string, librdl string, prefi
 		err = GenerateGoServer(banner, schema, dirName, ns, librdl, prefixEnums, preciseTypes)
 	case "go-client":
 		err = GenerateGoClient(banner, schema, dirName, ns, librdl, prefixEnums, preciseTypes)
+	case "go-server-project":
+		err = GenerateGoServerProject(schemaFile, banner, schema, dirName, ns, librdl, prefixEnums, preciseTypes, untaggedUnions)
 	case "java-model":
 		err = GenerateJavaModel(banner, schema, dirName, ns, externalOptions)
 	case "java-server":


### PR DESCRIPTION
Creates project structure, model, server, and a main with stubs for
each method implementation. The --ns option is used to specify the github repo the resulting project resides in, so a correct client usage in a different package can be correctly generated.