### PR TITLE
Fixed regression on alt naming.

### DIFF
--- a/rdl/go-server.go
+++ b/rdl/go-server.go
@@ -601,7 +601,7 @@ func goMethodName2(reg rdl.TypeRegistry, r *rdl.Resource, precise bool, packageN
 	if meth == "" {
 		meth = strings.ToLower(string(r.Method)) + bodyType
 	} else {
-		meth = uncapitalize(SnakeToCamel(meth))
+		meth = uncapitalize(meth)
 	}
 	return meth, params
 }


### PR DESCRIPTION
The fix previously was to uncapitalize, not to additionally call SnakeToCamel, which trashes well formed Camel case names.