### PR TITLE
Bugfix for setProperty method, make clients compatible with sending cookies

### DIFF
--- a/rdl/java-client.go
+++ b/rdl/java-client.go
@@ -135,6 +135,7 @@ public class {{cName}}Client {
 
     public {{cName}}Client setProperty(String name, Object value) {
         client = client.property(name, value);
+        base = client.target(base.getUri().toString());
         return this;
     }
 

--- a/rdl/java-client.go
+++ b/rdl/java-client.go
@@ -202,7 +202,8 @@ func (gen *javaClientGenerator) clientMethodBody(r *rdl.Resource) string {
 	if r.Auth != nil {
 		if r.Auth.Authenticate || (r.Auth.Action != "" && r.Auth.Resource != "") {
 			s += "\n        if (credsHeader != null) {"
-			s += "\n            invocationBuilder = invocationBuilder.header(credsHeader, credsToken);"
+			s += "\n            invocationBuilder = credsHeader.startsWith(\"Cookie.\") ? invocationBuilder.cookie(credsHeader.substring(7),"
+			s += "\n                credsToken) : invocationBuilder.header(credsHeader, credsToken);"
 			s += "\n        }"
 		} else {
 			log.Println("*** Badly formed auth spec in resource input:", r)


### PR DESCRIPTION
setProperty is not currently working because the instance "client" is generating WebTarget instance in constructor.