### PR TITLE
add hooks to provide your own jax rs Client

### DIFF
--- a/rdl/java-client.go
+++ b/rdl/java-client.go
@@ -129,6 +129,11 @@ public class {{cName}}Client {
         base = client.target(url);
     }
 
+    public {{cName}}Client(String url, Client rsClient) {
+        client = rsClient;
+        base = client.target(url);
+    }
+    
     public void close() {
         client.close();
     }


### PR DESCRIPTION
Users can use ClientBuilder to generate the client with specific requirements such as providing ssl context etc.

Example: 
        Client client = ClientBuilder.newBuilder()
                .hostnameVerifier(hostnameVerifier)
                .sslContext(sslContext)
                .property("jersey.config.client.connectTimeout", "2000").build();
        ztsClient = new ZTSRDLGeneratedClient(ztsUrl, client);
