### PR TITLE
Additional parameter type parsing

### DIFF
--- a/rdl/go-server.go
+++ b/rdl/go-server.go
@@ -343,6 +343,8 @@ func goHandlerBody(reg rdl.TypeRegistry, name string, r *rdl.Resource, precise b
 				} else {
 					s += fmt.Sprintf("\t%s := floatFromString(context.Params[%q])\n", name, in.Name)
 				}
+			case "UUID":
+				s += fmt.Sprintf("\t%s := rdl.Parse%s(context.Params[%q])\n", name, in.Type, in.Name)
 			default:
 				if precise && strings.ToLower(string(in.Type)) != "string" {
 					s += fmt.Sprintf("\t%s := %s(context.Params[%q])\n", name, in.Type, in.Name)

--- a/rdl/go-server.go
+++ b/rdl/go-server.go
@@ -343,6 +343,8 @@ func goHandlerBody(reg rdl.TypeRegistry, name string, r *rdl.Resource, precise b
 				} else {
 					s += fmt.Sprintf("\t%s := floatFromString(context.Params[%q])\n", name, in.Name)
 				}
+			case "Timestamp":
+				s += fmt.Sprintf("\t%s, _ := rdl.%sParse(context.Params[%q])\n", name, in.Type, in.Name)
 			case "UUID":
 				s += fmt.Sprintf("\t%s := rdl.Parse%s(context.Params[%q])\n", name, in.Type, in.Name)
 			default:


### PR DESCRIPTION
This adds support for converting Timestamp and UUID REST parameters into their corresponding RDL types via `rdl.ParseTimestamp` and `rdl.ParseUUID`. Otherwise, using such types in an RDL definition and generating server code results in a build error.