### PR TITLE
Added support for Timestamp, UUID query param types

### DIFF
--- a/rdl/go-client.go
+++ b/rdl/go-client.go
@@ -309,6 +309,18 @@ func encodeInt64Param(name string, i int64, def int64) string {
 	}
 	return "&" + name + "=" + strconv.FormatInt(i, 10)
 }
+func encodeTimestampParam(name string, i rdl.Timestamp, def rdl.Timestamp) string {
+	if i == def {
+		return ""
+	}
+	return "&" + name + "=" + url.QueryEscape(i.String())
+}
+func encodeUUIDParam(name string, i rdl.UUID, def rdl.UUID) string {
+	if i.Equal(def) {
+		return ""
+	}
+	return "&" + name + "=" + i.String()
+}
 func encodeFloat32Param(name string, i float32, def float32) string {
 	if i == def {
 		return ""
@@ -344,6 +356,18 @@ func encodeOptionalInt64Param(name string, i *int64) string {
 		return ""
 	}
 	return "&" + name + "=" + strconv.Itoa(int(*i))
+}
+func encodeOptionalTimestampParam(name string, i *rdl.Timestamp) string {
+	if i == nil {
+		return ""
+	}
+	return "&" + name + "=" + url.QueryEscape(i.String())
+}
+func encodeOptionalUUIDParam(name string, i *rdl.UUID) string {
+	if i == nil {
+		return ""
+	}
+	return "&" + name + "=" + i.String()
 }
 func encodeParams(objs ...string) string {
 	s := strings.Join(objs, "")

--- a/rdl/go-server.go
+++ b/rdl/go-server.go
@@ -550,6 +550,56 @@ func goParamInit(reg rdl.TypeRegistry, qname string, pname string, ptype rdl.Typ
 					s += "\t" + pname + " := New" + gtype + "(" + pname + "Optional)\n"
 				}
 			}
+		case rdl.BaseTypeTimestamp:
+			stype := fmt.Sprint(bt)
+			errData := "&rdl.ResourceError{Code: 400, Message: \"Invalid " + stype + "\"}"
+			if pdefault == nil {
+				s += fmt.Sprintf("\tvar %s *%s\n", pname, gtype)
+				s += fmt.Sprintf("\t%sOptional := rdl.OptionalStringParam(request, %q)\n", pname, qname)
+				s += fmt.Sprintf("\tif %sOptional != \"\" {\n", pname)
+				s += "\t\tp" + pname + ", err := rdl." + stype + "Parse(" + pname + "Optional)\n"
+				s += "\tif err != nil {\n"
+				s += "\t\trdl.JSONResponse(writer, 400, " + errData + ")\n"
+				s += "\t\treturn\n"
+				s += "\t}\n"
+				s += "\t\t" + pname + " = &p" + pname + "\n"
+				s += "\t}\n"
+			} else {
+				s += fmt.Sprintf("\t%sOptional, _ := rdl.StringParam(request, %q, %v.String())\n", pname, qname, pdefault)
+				s += "\tp" + pname + " := rdl." + stype + "Parse(" + pname + "Optional)\n"
+				s += "\tif err != nil {\n"
+				s += "\t\trdl.JSONResponse(writer, 400, " + errData + ")\n"
+				s += "\t\treturn\n"
+				s += "\t}\n"
+				if poptional {
+					s += "\t" + pname + " := &p" + pname + "\n"
+				}
+			}
+		case rdl.BaseTypeUUID:
+			stype := fmt.Sprint(bt)
+			errData := "&rdl.ResourceError{Code: 400, Message: \"Invalid " + stype + "\"}"
+			if pdefault == nil {
+				s += fmt.Sprintf("\tvar %s *%s\n", pname, gtype)
+				s += fmt.Sprintf("\t%sOptional := rdl.OptionalStringParam(request, %q)\n", pname, qname)
+				s += fmt.Sprintf("\tif %sOptional != \"\" {\n", pname)
+				s += "\t\tp" + pname + " := rdl.Parse" + stype + "(" + pname + "Optional)\n"
+				s += "\tif p" + pname + " == nil {\n"
+				s += "\t\trdl.JSONResponse(writer, 400, " + errData + ")\n"
+				s += "\t\treturn\n"
+				s += "\t}\n"
+				s += "\t\t" + pname + " = &p" + pname + "\n"
+				s += "\t}\n"
+			} else {
+				s += fmt.Sprintf("\t%sOptional, _ := rdl.StringParam(request, %q, %v.String())\n", pname, qname, pdefault)
+				s += "\tp" + pname + " := rdl.Parse" + stype + "(" + pname + "Optional)\n"
+				s += "\tif p" + pname + " == nil {\n"
+				s += "\t\trdl.JSONResponse(writer, 400, " + errData + ")\n"
+				s += "\t\treturn\n"
+				s += "\t}\n"
+				if poptional {
+					s += "\t" + pname + " := &p" + pname + "\n"
+				}
+			}
 		default:
 			fmt.Println("fix me:", pname, "of type", gtype, "with base type", bt)
 			panic("fix me")


### PR DESCRIPTION
This adds support for using Timestamp and UUID templated parameters when used in the query string in an endpoint, e.g. supports this snippet of RDL:

```
resource Things GET "/api/foo?bar={bar}&baz={baz}" {
  Timestamp bar (optional);
  UUID baz (optional);
}
```

If the value cannot be parsed, then the server replies with code=400 and message="Invalid Timestamp" or "Invalid UUID".