### PR TITLE
honor consumes directive instead of always using application/json

### DIFF
--- a/rdl/java-client.go
+++ b/rdl/java-client.go
@@ -222,10 +222,14 @@ func (gen *javaClientGenerator) clientMethodBody(r *rdl.Resource) string {
 	s += "\n"
 	switch r.Method {
 	case "PUT", "POST", "PATCH":
+		contentType := "application/json"
+		if len(r.Consumes) > 0 {
+			contentType = r.Consumes[0]
+		}
 		if entityName == "" {
-			s += "        Response response = invocationBuilder." + strings.ToLower(r.Method) + "(javax.ws.rs.client.Entity.entity(null, \"application/json\"));\n"
+			s += "        Response response = invocationBuilder." + strings.ToLower(r.Method) + "(javax.ws.rs.client.Entity.entity(null, \"" + contentType + "\"));\n"
 		} else {
-			s += "        Response response = invocationBuilder." + strings.ToLower(r.Method) + "(javax.ws.rs.client.Entity.entity(" + entityName + ", \"application/json\"));\n"
+			s += "        Response response = invocationBuilder." + strings.ToLower(r.Method) + "(javax.ws.rs.client.Entity.entity(" + entityName + ", \"" + contentType + "\"));\n"
 		}
 	default:
 		s += "        Response response = invocationBuilder." + strings.ToLower(r.Method) + "();\n"


### PR DESCRIPTION
When we have an rdl like:

resource AccessTokenResponse POST "/oauth2/token" {
    authenticate;
    AccessTokenRequest request;
    consumes application/x-www-form-urlencoded
    exceptions {
        ResourceError BAD_REQUEST;
        ResourceError FORBIDDEN;
        ResourceError NOT_FOUND;
        ResourceError UNAUTHORIZED;
    }
}

rdl correctly parses and maintains the consumes directive but when generating the client it ignores it and uses application/json always. the PR honors this setting if configured otherwise defaults to json.